### PR TITLE
Add node_modules directory to the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ out
 .settings
 .idea
 *.iml
+node_modules/


### PR DESCRIPTION
# Adding Node Modules directory to the .gitignore

## Introduction
To make sure that the repository is not bloated, its important to future proof the project by adding `node_modules` to the project `.gitignore` file. Therefore, in the future, no matter whether you're Angular or React or Vue or React, the project repo will be kept sane. 

## Merge Changes
* Add `node_modules` to the `.gitignore` file

## Conclusion
Donations accepted on my Patreon.